### PR TITLE
Fix empty changelog

### DIFF
--- a/slack/prepare_slack_msg.sh
+++ b/slack/prepare_slack_msg.sh
@@ -2,7 +2,7 @@ LIB_PROP_FILE="lib.properties"
 VERSION_NAME=`cat $LIB_PROP_FILE | grep VERSION_NAME | cut -d = -f 2`
 SITE_URL=`cat $LIB_PROP_FILE | grep SITE_URL | cut -d = -f 2`
 LIB_NAME=`echo $SITE_URL | cut -d / -f 5`
-GIT_CHANGELOG=`git log $(git describe --tags --abbrev=0)..HEAD --oneline --no-decorate | cut -d ' ' -f 2- | tail -n +3`
+GIT_CHANGELOG=`git log $(git describe --tags --abbrev=0 --always $(git rev-list --tags --skip=1 --max-count=1))..HEAD --oneline --no-decorate | cut -d ' ' -f 2- | tail -n +2`
 export SLACK_MSG_TITLE="$LIB_NAME $VERSION_NAME released :tada:"
 export SLACK_MSG="Changes:
 $GIT_CHANGELOG


### PR DESCRIPTION
Fix empty changelog: compare second from the last tag instead of latest, because deploy action is always ran after tag is pushed, so diff between HEAD and latest tag was empty.